### PR TITLE
compare IMPASSABLE_CHUNKs by name not reference

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -157,7 +157,7 @@ local function onIonCannonFired(event)
         natives.ionCannonBlasts = natives.ionCannonBlasts + 1
         natives.points = natives.points + 3000
         local chunk = getChunkByPosition(map, event.position)
-        if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+        if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
             rallyUnits(chunk, map, surface, event.tick)
         end
     end
@@ -622,7 +622,7 @@ local function onDeath(event)
             end
 
             if (entityType == "unit") then
-                if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+                if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                     -- drop death pheromone where unit died
                     deathScent(map, chunk)
 
@@ -649,7 +649,7 @@ local function onDeath(event)
 
                 natives.points = natives.points + (((entityType == "unit-spawner") and RECOVER_NEST_COST) or RECOVER_WORM_COST)
 
-                if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+                if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                     unregisterEnemyBaseStructure(map, entity)
 
                     rallyUnits(chunk, map, surface, tick)
@@ -687,7 +687,7 @@ local function onDeath(event)
             local creditNatives = false
             if (event.force ~= nil) and (event.force.name == "enemy") then
                 creditNatives = true
-                if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+                if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                     victoryScent(map, chunk, entityType)
                 end
 
@@ -748,7 +748,7 @@ local function onEnemyBaseBuild(event)
 
     if entity.valid and (surface.name == natives.activeSurface) then
         local chunk = getChunkByPosition(map, entity.position)
-        if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+        if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
             local base
             if natives.newEnemies then
                 base = findNearbyBase(map, chunk)
@@ -784,7 +784,7 @@ local function onSurfaceTileChange(event)
             local position = tiles[i].position
             local chunk = getChunkByPosition(map, position)
 
-            if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+            if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                 map.chunkToPassScan[chunk] = true
             else
                 local x,y = positionToChunkXY(position)
@@ -848,7 +848,7 @@ local function onTriggerEntityCreated(event)
     local entity = event.entity
     if entity.valid and (entity.name  == "drain-trigger-rampant") then
         local chunk = getChunkByPosition(map, entity.position)
-        if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+        if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
             map.chunkToDrained[chunk] = event.tick + 60
         end
         entity.destroy()
@@ -883,7 +883,7 @@ local function onEntitySpawned(event)
                 local canPlaceQuery = map.canPlaceQuery
 
                 local chunk = getChunkByPosition(map, disPos)
-                if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+                if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                     local base = findNearbyBase(map, chunk)
                     if not base then
                         base = createBase(natives,

--- a/libs/AIAttackWave.lua
+++ b/libs/AIAttackWave.lua
@@ -132,7 +132,7 @@ function aiAttackWave.rallyUnits(chunk, map, surface, tick)
             for y=cY - RALLY_CRY_DISTANCE, cY + RALLY_CRY_DISTANCE, 32 do
                 if (x ~= cX) and (y ~= cY) then
                     local rallyChunk = getChunkByXY(map, x, y)
-                    if (rallyChunk ~= SENTINEL_IMPASSABLE_CHUNK) and (getNestCount(map, rallyChunk) > 0) then
+                    if (rallyChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (getNestCount(map, rallyChunk) > 0) then
                         if not aiAttackWave.formVengenceSquad(map, surface, rallyChunk) then
                             return false
                         end
@@ -152,7 +152,7 @@ function aiAttackWave.formAttackWave(chunk, map, surface, tick)
             for y=cY - RALLY_CRY_DISTANCE, cY + RALLY_CRY_DISTANCE, 32 do
                 if (x ~= cX) and (y ~= cY) then
                     local rallyChunk = getChunkByXY(map, x, y)
-                    if (rallyChunk ~= SENTINEL_IMPASSABLE_CHUNK) and (getNestCount(map, rallyChunk) > 0) then
+                    if (rallyChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (getNestCount(map, rallyChunk) > 0) then
                         if not aiAttackWave.formSquads(map, surface, rallyChunk, tick) then
                             return false
                         end
@@ -172,7 +172,7 @@ local function noNearbySettlers(map, chunk, tick)
         for y=cY - SETTLER_DISTANCE, cY + SETTLER_DISTANCE, 32 do
             if (x ~= cX) and (y ~= cY) then
                 local c = getChunkByXY(map, x, y)
-                if (c ~= SENTINEL_IMPASSABLE_CHUNK) and ((tick - getChunkSettlerTick(map, c)) < 0) then
+                if (c.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and ((tick - getChunkSettlerTick(map, c)) < 0) then
                     return false
                 end
             end
@@ -199,7 +199,7 @@ function aiAttackWave.formSettlers(map, surface, chunk, tick)
                                                                   map)
         end
 
-        if (squadPath ~= SENTINEL_IMPASSABLE_CHUNK) and noNearbySettlers(map, chunk, tick) then
+        if (squadPath.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and noNearbySettlers(map, chunk, tick) then
             local squadPosition = surface.find_non_colliding_position("chunk-scanner-squad-rampant",
                                                                       positionFromDirectionAndChunk(squadDirection,
                                                                                                     chunk,
@@ -248,7 +248,7 @@ function aiAttackWave.formVengenceSquad(map, surface, chunk)
                                                                      validUnitGroupLocation,
                                                                      scoreUnitGroupLocation,
                                                                      map)
-        if (squadPath ~= SENTINEL_IMPASSABLE_CHUNK) then
+        if (squadPath.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
             local squadPosition = surface.find_non_colliding_position("chunk-scanner-squad-rampant",
                                                                       positionFromDirectionAndChunk(squadDirection,
                                                                                                     chunk,
@@ -295,7 +295,7 @@ function aiAttackWave.formSquads(map, surface, chunk, tick)
                                                                      validUnitGroupLocation,
                                                                      scoreUnitGroupLocation,
                                                                      map)
-        if (squadPath ~= SENTINEL_IMPASSABLE_CHUNK) then
+        if (squadPath.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
             local squadPosition = surface.find_non_colliding_position("chunk-scanner-squad-rampant",
                                                                       positionFromDirectionAndChunk(squadDirection,
                                                                                                     chunk,

--- a/libs/ChunkProcessor.lua
+++ b/libs/ChunkProcessor.lua
@@ -83,7 +83,7 @@ function chunkProcessor.processPendingChunks(map, surface, pendingStack, tick, r
 
             chunk = initialScan(chunk, surface, map, tick, rebuilding)
 
-            if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+            if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                 map[x][y] = chunk
                 processQueue[#processQueue+1] = chunk
             end
@@ -122,7 +122,7 @@ function chunkProcessor.processScanChunks(map, surface)
 
         chunk = chunkPassScan(chunk, surface, map)
 
-        if (chunk == SENTINEL_IMPASSABLE_CHUNK) then
+        if (chunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
             map[x][y] = nil
 
             chunkCount = chunkCount + 1

--- a/libs/ChunkUtils.lua
+++ b/libs/ChunkUtils.lua
@@ -345,7 +345,7 @@ function chunkUtils.entityForPassScan(map, entity)
 
     for i=1,#overlapArray do
         local chunk = overlapArray[i]
-        if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+        if (chunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
             map.chunkToPassScan[chunk] = true
         end
     end
@@ -420,7 +420,7 @@ function chunkUtils.registerEnemyBaseStructure(map, entity, base, surface)
 
         for i=1,#overlapArray do
             local chunk = overlapArray[i]
-            if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+            if (chunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
                 setFunc(map, chunk, getFunc(map, chunk) + 1)
                 setChunkBase(map, chunk, base)
                 processNestActiveness(map, chunk, natives, surface)
@@ -475,7 +475,7 @@ function chunkUtils.unregisterEnemyBaseStructure(map, entity)
 
         for i=1,#overlapArray do
             local chunk = overlapArray[i]
-            if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+            if (chunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
                 local count = getFunc(map, chunk)
                 if count then
                     if (count <= 1) then
@@ -517,7 +517,7 @@ function chunkUtils.accountPlayerEntity(entity, natives, addObject, creditNative
 
         for i=1,#overlapArray do
             local chunk = overlapArray[i]
-            if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+            if (chunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
                 addPlayerBaseGenerator(map, chunk, entityValue)
             end
         end
@@ -533,7 +533,7 @@ function chunkUtils.unregisterResource(entity, map)
 
     for i=1,#overlapArray do
         local chunk = overlapArray[i]
-        if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+        if (chunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
             addResourceGenerator(map, chunk, -RESOURCE_NORMALIZER)
         end
     end
@@ -544,7 +544,7 @@ function chunkUtils.registerResource(entity, map)
 
     for i=1,#overlapArray do
         local chunk = overlapArray[i]
-        if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+        if (chunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
             addResourceGenerator(map, chunk, RESOURCE_NORMALIZER)
         end
     end

--- a/libs/MapProcessor.lua
+++ b/libs/MapProcessor.lua
@@ -230,7 +230,7 @@ function mapProcessor.processPlayers(players, map, surface, tick)
         if validPlayer(player, natives) then
             local playerChunk = getChunkByPosition(map, player.character.position)
 
-            if (playerChunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+            if (playerChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                 local i = 1
                 local vengence = (allowingAttacks and
                                       (natives.points >= AI_VENGENCE_SQUAD_COST) and
@@ -240,7 +240,7 @@ function mapProcessor.processPlayers(players, map, surface, tick)
                     for y=playerChunk.y - PROCESS_PLAYER_BOUND, playerChunk.y + PROCESS_PLAYER_BOUND, 32 do
                         local chunk = getChunkByXY(map, x, y)
 
-                        if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) and (chunk[CHUNK_TICK] ~= tick) then
+                        if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (chunk[CHUNK_TICK] ~= tick) then
                             processPheromone(map, chunk, scentStaging[i])
 
                             processNestActiveness(map, chunk, natives, surface)
@@ -258,7 +258,7 @@ function mapProcessor.processPlayers(players, map, surface, tick)
                 for x=playerChunk.x - PROCESS_PLAYER_BOUND, playerChunk.x + PROCESS_PLAYER_BOUND, 32 do
                     for y=playerChunk.y - PROCESS_PLAYER_BOUND, playerChunk.y + PROCESS_PLAYER_BOUND, 32 do
                         local chunk = getChunkByXY(map, x, y)
-                        if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) and (chunk[CHUNK_TICK] ~= tick) then
+                        if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (chunk[CHUNK_TICK] ~= tick) then
                             commitPheromone(map, chunk, scentStaging[i], tick)
                         end
                         i = i + 1
@@ -273,7 +273,7 @@ function mapProcessor.processPlayers(players, map, surface, tick)
         if validPlayer(player, natives) then
             local playerChunk = getChunkByPosition(map, player.character.position)
 
-            if (playerChunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+            if (playerChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                 playerScent(playerChunk)
             end
         end

--- a/libs/MovementUtils.lua
+++ b/libs/MovementUtils.lua
@@ -101,8 +101,8 @@ function movementUtils.scoreNeighborsForAttack(map, chunk, neighborDirectionChun
     for x=1,8 do
         local neighborChunk = neighborDirectionChunks[x]
 
-        if ((neighborChunk ~= SENTINEL_IMPASSABLE_CHUNK) and canMoveChunkDirection(map, x, chunk, neighborChunk)) or
-        (chunk == SENTINEL_IMPASSABLE_CHUNK) then
+        if ((neighborChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and canMoveChunkDirection(map, x, chunk, neighborChunk)) or
+        (chunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
             local score = scoreFunction(natives, squad, neighborChunk)
             if (score > highestScore) then
                 highestScore = score
@@ -112,12 +112,12 @@ function movementUtils.scoreNeighborsForAttack(map, chunk, neighborDirectionChun
         end
     end
 
-    if (highestChunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+    if (highestChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
         neighborDirectionChunks = getNeighborChunks(map, highestChunk.x, highestChunk.y)
         for x=1,8 do
             local neighborChunk = neighborDirectionChunks[x]
 
-            if ((neighborChunk ~= SENTINEL_IMPASSABLE_CHUNK) and (neighborChunk ~= chunk) and
+            if ((neighborChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (neighborChunk ~= chunk) and
                 canMoveChunkDirection(map, x, highestChunk, neighborChunk)) then
                 local score = scoreFunction(natives, squad, neighborChunk)
                 if (score > nextHighestScore) then
@@ -147,8 +147,8 @@ function movementUtils.scoreNeighborsForSettling(map, chunk, neighborDirectionCh
 
     for x=1,8 do
         local neighborChunk = neighborDirectionChunks[x]
-        if ((neighborChunk ~= SENTINEL_IMPASSABLE_CHUNK) and canMoveChunkDirection(map, x, chunk, neighborChunk)) or
-        (chunk == SENTINEL_IMPASSABLE_CHUNK) then
+        if ((neighborChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and canMoveChunkDirection(map, x, chunk, neighborChunk)) or
+        (chunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
             local score = scoreFunction(squad, neighborChunk)
             if (score > highestScore) then
                 highestScore = score
@@ -158,7 +158,7 @@ function movementUtils.scoreNeighborsForSettling(map, chunk, neighborDirectionCh
         end
     end
 
-    if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) and (scoreFunction(squad, chunk) > highestScore) then
+    if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (scoreFunction(squad, chunk) > highestScore) then
         return chunk, 0, SENTINEL_IMPASSABLE_CHUNK, 0
     end
 
@@ -166,12 +166,12 @@ function movementUtils.scoreNeighborsForSettling(map, chunk, neighborDirectionCh
     local nextHighestScore = -MAGIC_MAXIMUM_NUMBER
     local nextHighestDirection = 0
 
-    if (highestChunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+    if (highestChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
         neighborDirectionChunks = getNeighborChunks(map, highestChunk.x, highestChunk.y)
         for x=1,8 do
             local neighborChunk = neighborDirectionChunks[x]
 
-            if ((neighborChunk ~= SENTINEL_IMPASSABLE_CHUNK) and (neighborChunk ~= chunk) and
+            if ((neighborChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (neighborChunk ~= chunk) and
                 canMoveChunkDirection(map, x, highestChunk, neighborChunk)) then
                 local score = scoreFunction(squad, neighborChunk)
                 if (score > nextHighestScore) then
@@ -195,7 +195,7 @@ function movementUtils.scoreNeighborsForResource(chunk, neighborDirectionChunks,
     local highestDirection
     for x=1,8 do
         local neighborChunk = neighborDirectionChunks[x]
-        if (neighborChunk ~= SENTINEL_IMPASSABLE_CHUNK) and canMoveChunkDirection(map, x, chunk, neighborChunk) and validFunction(map, chunk, neighborChunk) then
+        if (neighborChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and canMoveChunkDirection(map, x, chunk, neighborChunk) and validFunction(map, chunk, neighborChunk) then
             local score = scoreFunction(neighborChunk)
             if (score > highestScore) then
                 highestScore = score
@@ -205,7 +205,7 @@ function movementUtils.scoreNeighborsForResource(chunk, neighborDirectionChunks,
         end
     end
 
-    if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) and (scoreFunction(chunk) > highestScore) then
+    if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (scoreFunction(chunk) > highestScore) then
         return SENTINEL_IMPASSABLE_CHUNK, -1
     end
 
@@ -226,8 +226,8 @@ function movementUtils.scoreNeighborsForRetreat(chunk, neighborDirectionChunks, 
 
     for x=1,8 do
         local neighborChunk = neighborDirectionChunks[x]
-        if ((neighborChunk ~= SENTINEL_IMPASSABLE_CHUNK) and canMoveChunkDirection(map, x, chunk, neighborChunk)) or
-        (chunk == SENTINEL_IMPASSABLE_CHUNK) then
+        if ((neighborChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and canMoveChunkDirection(map, x, chunk, neighborChunk)) or
+        (chunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
             local score = scoreFunction(map, neighborChunk)
             if (score > highestScore) then
                 highestScore = score
@@ -237,12 +237,12 @@ function movementUtils.scoreNeighborsForRetreat(chunk, neighborDirectionChunks, 
         end
     end
 
-    if (highestChunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+    if (highestChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
         neighborDirectionChunks = getNeighborChunks(map, highestChunk.x, highestChunk.y)
         for x=1,8 do
             local neighborChunk = neighborDirectionChunks[x]
 
-            if ((neighborChunk ~= SENTINEL_IMPASSABLE_CHUNK) and (neighborChunk ~= chunk) and
+            if ((neighborChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (neighborChunk ~= chunk) and
                 canMoveChunkDirection(map, x, highestChunk, neighborChunk)) then
                 local score = scoreFunction(map, neighborChunk)
                 if (score > nextHighestScore) then
@@ -271,7 +271,7 @@ function movementUtils.scoreNeighborsForFormation(neighborChunks, validFunction,
     local highestDirection
     for x=1,8 do
         local neighborChunk = neighborChunks[x]
-        if (neighborChunk ~= SENTINEL_IMPASSABLE_CHUNK) and validFunction(map, neighborChunk) then
+        if (neighborChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and validFunction(map, neighborChunk) then
             local score = scoreFunction(neighborChunk)
             if (score > highestScore) then
                 highestScore = score

--- a/libs/PheromoneUtils.lua
+++ b/libs/PheromoneUtils.lua
@@ -116,7 +116,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
     if (chunkPass == CHUNK_ALL_DIRECTIONS) then
         neighbor = tempNeighbors[2]
         neighborPass = getPassable(map, neighbor)
-        if ((neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and
+        if ((neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and
             ((neighborPass == CHUNK_ALL_DIRECTIONS) or (neighborPass == CHUNK_NORTH_SOUTH))) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
@@ -127,7 +127,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[7]
         neighborPass = getPassable(map, neighbor)
-        if ((neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and
+        if ((neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and
             ((neighborPass == CHUNK_ALL_DIRECTIONS) or (neighborPass == CHUNK_NORTH_SOUTH))) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
@@ -138,7 +138,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[4]
         neighborPass = getPassable(map, neighbor)
-        if ((neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and
+        if ((neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and
             ((neighborPass == CHUNK_ALL_DIRECTIONS) or (neighborPass == CHUNK_EAST_WEST))) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
@@ -149,7 +149,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[5]
         neighborPass = getPassable(map, neighbor)
-        if ((neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and
+        if ((neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and
             ((neighborPass == CHUNK_ALL_DIRECTIONS) or (neighborPass == CHUNK_EAST_WEST))) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
@@ -160,7 +160,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[1]
         neighborPass = getPassable(map, neighbor)
-        if (neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and (neighborPass == CHUNK_ALL_DIRECTIONS) then
+        if (neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (neighborPass == CHUNK_ALL_DIRECTIONS) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
             baseTotal = baseTotal + (neighbor[BASE_PHEROMONE] - chunkBase)
@@ -170,7 +170,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[3]
         neighborPass = getPassable(map, neighbor)
-        if (neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and (neighborPass == CHUNK_ALL_DIRECTIONS) then
+        if (neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (neighborPass == CHUNK_ALL_DIRECTIONS) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
             baseTotal = baseTotal + (neighbor[BASE_PHEROMONE] - chunkBase)
@@ -180,7 +180,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[6]
         neighborPass = getPassable(map, neighbor)
-        if (neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and (neighborPass == CHUNK_ALL_DIRECTIONS) then
+        if (neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (neighborPass == CHUNK_ALL_DIRECTIONS) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
             baseTotal = baseTotal + (neighbor[BASE_PHEROMONE] - chunkBase)
@@ -190,7 +190,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[8]
         neighborPass = getPassable(map, neighbor)
-        if (neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and (neighborPass == CHUNK_ALL_DIRECTIONS) then
+        if (neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (neighborPass == CHUNK_ALL_DIRECTIONS) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
             baseTotal = baseTotal + (neighbor[BASE_PHEROMONE] - chunkBase)
@@ -202,7 +202,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[4]
         neighborPass = getPassable(map, neighbor)
-        if ((neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and
+        if ((neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and
             ((neighborPass == CHUNK_ALL_DIRECTIONS) or (neighborPass == CHUNK_EAST_WEST))) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
@@ -213,7 +213,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[5]
         neighborPass = getPassable(map, neighbor)
-        if ((neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and
+        if ((neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and
             ((neighborPass == CHUNK_ALL_DIRECTIONS) or (neighborPass == CHUNK_EAST_WEST))) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
@@ -226,7 +226,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[2]
         neighborPass = getPassable(map, neighbor)
-        if ((neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and
+        if ((neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and
             ((neighborPass == CHUNK_ALL_DIRECTIONS) or (neighborPass == CHUNK_NORTH_SOUTH))) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)
@@ -237,7 +237,7 @@ function pheromoneUtils.processPheromone(map, chunk, staging)
 
         neighbor = tempNeighbors[7]
         neighborPass = getPassable(map, neighbor)
-        if ((neighbor ~= SENTINEL_IMPASSABLE_CHUNK) and
+        if ((neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and
             ((neighborPass == CHUNK_ALL_DIRECTIONS) or (neighborPass == CHUNK_NORTH_SOUTH))) then
             neighborCount = neighborCount + 1
             movementTotal = movementTotal + (neighbor[MOVEMENT_PHEROMONE] - chunkMovement)

--- a/libs/SquadAttack.lua
+++ b/libs/SquadAttack.lua
@@ -134,10 +134,10 @@ local function settleMove(map, squad, surface)
     if (natives.state == AI_STATE_SIEGE) then
         scoreFunction = scoreSiegeLocation
     end
-    if squad.chunk and (squad.chunk ~= SENTINEL_IMPASSABLE_CHUNK) and (squad.chunk ~= chunk) then
+    if squad.chunk and (squad.chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (squad.chunk ~= chunk) then
         addMovementPenalty(squad, squad.chunk)
     end
-    if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+    if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
         addSquadToChunk(map, chunk, squad)
     end
     local distance = euclideanDistancePoints(groupPosition.x,
@@ -195,7 +195,7 @@ local function settleMove(map, squad, surface)
                                                                                                              scoreFunction,
                                                                                                              squad)
 
-        if (attackChunk == SENTINEL_IMPASSABLE_CHUNK) then
+        if (attackChunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
             squad.cycles = 30
             cmd = map.wonderCommand
             group.set_command(cmd)
@@ -235,7 +235,7 @@ local function settleMove(map, squad, surface)
                 end
             end
 
-            if (nextAttackChunk ~= SENTINEL_IMPASSABLE_CHUNK) then                
+            if (nextAttackChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then                
                 positionFromDirectionAndFlat(nextAttackDirection, targetPosition, targetPosition2)
 
                 position2 = findMovementPosition(surface, targetPosition2)
@@ -305,10 +305,10 @@ local function attackMove(map, squad, surface)
         or scoreAttackLocation
 
     local squadChunk = squad.chunk
-    if (squadChunk ~= SENTINEL_IMPASSABLE_CHUNK) and (squadChunk ~= chunk) then
+    if (squadChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) and (squadChunk ~= chunk) then
         addMovementPenalty(squad, squadChunk)
     end
-    if (chunk ~= SENTINEL_IMPASSABLE_CHUNK)then
+    if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name)then
         addSquadToChunk(map, chunk, squad)
     end
     squad.frenzy = (squad.frenzy and (euclideanDistanceNamed(groupPosition, squad.frenzyPosition) < 100))
@@ -317,7 +317,7 @@ local function attackMove(map, squad, surface)
                                                                                                        getNeighborChunks(map, x, y),
                                                                                                        attackScorer,
                                                                                                        squad)
-    if (attackChunk == SENTINEL_IMPASSABLE_CHUNK) then
+    if (attackChunk.name == SENTINEL_IMPASSABLE_CHUNK.name) then
         squad.cycles = 30
         cmd = map.wonderCommand
         group.set_command(cmd)
@@ -359,7 +359,7 @@ local function attackMove(map, squad, surface)
 
         local position2
 
-        if (nextAttackChunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+        if (nextAttackChunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
             positionFromDirectionAndFlat(nextAttackDirection, targetPosition, targetPosition2)
 
             position2 = findMovementPosition(surface, targetPosition2)
@@ -436,7 +436,7 @@ function squadAttack.squadsDispatch(map, surface)
                         attackMove(map, squad, surface)
                     else
                         local chunk = getChunkByPosition(map, group.position)
-                        if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+                        if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                             addSquadToChunk(map, chunk, squad)
                         end
                     end
@@ -450,7 +450,7 @@ function squadAttack.squadsDispatch(map, surface)
                         settleMove(map, squad, surface)
                     else
                         local chunk = getChunkByPosition(map, group.position)
-                        if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+                        if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                             addSquadToChunk(map, chunk, squad)
                         end
                     end
@@ -467,7 +467,7 @@ function squadAttack.squadsDispatch(map, surface)
                         squads[x] = squad
                     end
                     local chunk = getChunkByPosition(map, group.position)
-                    if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+                    if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                         addSquadToChunk(map, chunk, squad)
                     end
                 elseif (status == SQUAD_BUILDING) then

--- a/libs/SquadDefense.lua
+++ b/libs/SquadDefense.lua
@@ -92,7 +92,7 @@ function aiDefense.retreatUnits(chunk, position, squad, map, surface, tick, radi
                                                                                                                       chunk.y),
                                                                                                     scoreRetreatLocation,
                                                                                                     map)
-            if (exitPath ~= SENTINEL_IMPASSABLE_CHUNK) then
+            if (exitPath.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                 local targetPosition = map.position
                 local targetPosition2 = map.position2
 
@@ -104,7 +104,7 @@ function aiDefense.retreatUnits(chunk, position, squad, map, surface, tick, radi
                     return
                 end
 
-                if (nextExitPath ~= SENTINEL_IMPASSABLE_CHUNK) then
+                if (nextExitPath.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                     positionFromDirectionAndFlat(nextExitDirection, retreatPosition, targetPosition2)
 
                     local retreatPosition2 = findMovementPosition(surface, targetPosition2)

--- a/libs/UnitGroupUtils.lua
+++ b/libs/UnitGroupUtils.lua
@@ -63,7 +63,7 @@ function unitGroupUtils.findNearbyRetreatingSquad(map, chunk)
 
     for i=1,#neighbors do
         local neighbor = neighbors[i]
-        if neighbor ~= SENTINEL_IMPASSABLE_CHUNK then
+        if neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name then
             squads = getSquadsOnChunk(map, neighbor)
             for squadIndex=1,#squads do
                 local squad = squads[squadIndex]
@@ -92,7 +92,7 @@ function unitGroupUtils.findNearbySquad(map, chunk)
 
     for i=1,#neighbors do
         local neighbor = neighbors[i]
-        if neighbor ~= SENTINEL_IMPASSABLE_CHUNK then
+        if neighbor.name ~= SENTINEL_IMPASSABLE_CHUNK.name then
             squads = getSquadsOnChunk(map, neighbor)
             for squadIndex=1,#squads do
                 local squad = squads[squadIndex]
@@ -242,7 +242,7 @@ function unitGroupUtils.regroupSquads(natives)
                     local status = squad.status
                     local chunk = squad.chunk
 
-                    if (chunk ~= SENTINEL_IMPASSABLE_CHUNK) then
+                    if (chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name) then
                         local chunkSquads = getSquadsOnChunk(map, chunk)
                         for p=1,#chunkSquads do
                             local mergeSquad = chunkSquads[p]


### PR DESCRIPTION
Attempt to fix https://github.com/veden/Rampant/issues/27 by replacing `chunk ~= SENTINEL_IMPASSABLE_CHUNK` with `chunk.name ~= SENTINEL_IMPASSABLE_CHUNK.name` etc, since all strings are interned in LUA.

I have not yet tested to see if this fixes the problem, and I don't know if this is the right way to go about it.