### PR TITLE
quick fix SwarmUtil.lua for new slowdown sticker

### DIFF
--- a/prototypes/SwarmUtils.lua
+++ b/prototypes/SwarmUtils.lua
@@ -1025,14 +1025,7 @@ local function buildAttack(faction, template)
             end
         elseif (attack == "slow") then
             template.force = "not-same"
-            template.stickerAnimation = {
-                filename = "__base__/graphics/entity/slowdown-sticker/slowdown-sticker.png",
-                priority = "extra-high",
-                width = 11,
-                height = 11,
-                frame_count = 13,
-                animation_speed = 0.4
-            }
+            template.stickerAnimation = data.raw['stickers']['slowdown-sticker'].animation
             template.areaEffects = function (attributes)
                 return {
                     {


### PR DESCRIPTION
Since the original slowdown sticker definition was a copy of the animation from the base wube animation, I just assigned the new animation.  Tested that it doesn't blow up, didn't verify if there need to be graphical adjustments to the animation or anything.