### PR TITLE
Fix a non-recoverable error by supplying map

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -747,7 +747,7 @@ local function onUnitGroupCreated(event)
         universe.groupNumberToSquad[group.group_number] = squad
 
         if universe.NEW_ENEMIES then
-            local chunk = getChunkByPosition(group.position)
+            local chunk = getChunkByPosition(map, group.position)
             if (chunk ~= -1) then
                 squad.base = findNearbyBase(map, chunk)
             end


### PR DESCRIPTION
When `NEW_ENEMIES` is enabled, the game (or server) crashes after some time due to a non-recoverable error caused by line 750 because `getChunkByPosition` gets called without the `map` parameter.