### PR TITLE
fix redundant pollution-triggered activity

### DIFF
--- a/libs/ChunkPropertyUtils.lua
+++ b/libs/ChunkPropertyUtils.lua
@@ -628,20 +628,20 @@ function chunkPropertyUtils.processNestActiveness(map, chunk)
                 local position = {x=0,y=0}
                 position.x = x + 32
                 position.y = y
-                if (surface.get_pollution(position) > 0) then
+                if (surface.get_pollution(position) > 12.5) then
                     chunkPropertyUtils.setNestActiveness(map, chunk, mMin(activeness + 5, 20), base)
                 else
                     position.x = x - 32
-                    if (surface.get_pollution(position) > 0) then
+                    if (surface.get_pollution(position) > 12.5) then
                         chunkPropertyUtils.setNestActiveness(map, chunk, mMin(activeness + 5, 20), base)
                     else
                         position.x = x
                         position.y = y - 32
-                        if (surface.get_pollution(position) > 0) then
+                        if (surface.get_pollution(position) > 12.5) then
                             chunkPropertyUtils.setNestActiveness(map, chunk, mMin(activeness + 5, 20), base)
                         else
                             position.y = y + 32
-                            if (surface.get_pollution(position) > 0) then
+                            if (surface.get_pollution(position) > 12.5) then
                                 chunkPropertyUtils.setNestActiveness(map, chunk, mMin(activeness + 5, 20), base)
                             else
                                 chunkPropertyUtils.setNestActiveness(map, chunk, activeness - 2, base)

--- a/prototypes/SwarmUtils.lua
+++ b/prototypes/SwarmUtils.lua
@@ -468,7 +468,7 @@ local wormAttributeNumeric = {
     ["particleHoizontalSpeedDeviation"] = { 0.0025, 0.0025, 0.0024, 0.0024, 0.0023, 0.0023, 0.0022, 0.0022, 0.0021, 0.0021 },
     ["foldingSpeed"] = { 0.15, 0.15, 0.16, 0.16, 0.16, 0.17, 0.17, 0.18, 0.18, 0.19 },
     ["preparingSpeed"] = { 0.025, 0.025, 0.026, 0.026, 0.027, 0.027, 0.028, 0.028, 0.029, 0.029 },
-    ["prepareRange"] = { 30, 30, 35, 35, 40, 40, 40, 40, 45, 45 },
+    ["prepareRange"] = { 28, 30, 34, 36, 38, 39, 40, 41, 42, 43 },
     ["physicalDecrease"] = { 0, 0, 5, 5, 8, 8, 10, 10, 12, 12 },
     ["explosionDecrease"] = { 0, 0, 5, 5, 8, 8, 10, 10, 12, 12 },
     ["explosionPercent"] = { 0, 0, 10, 10, 20, 20, 30, 30, 40, 40 },
@@ -591,6 +591,7 @@ local function scaleAttributes (entity)
         entity["damage"] = entity["damage"] * settings.startup["rampant--unitWormDamageScaler"].value
         entity["damagePerTick"] = entity["damagePerTick"] * settings.startup["rampant--unitWormDamageScaler"].value
         entity["range"] = entity["range"] * settings.startup["rampant--unitWormRangeScaler"].value
+        entity["prepareRange"] = entity["prepareRange"] * settings.startup["rampant--unitWormRangeScaler"].value
         entity["healing"] = entity["healing"] * settings.startup["rampant--unitWormHealingScaler"].value
     elseif (entity.type == "hive") then
         entity["health"] = entity["health"] * settings.startup["rampant--unitHiveHealthScaler"].value

--- a/prototypes/utils/BiterUtils.lua
+++ b/prototypes/utils/BiterUtils.lua
@@ -295,7 +295,7 @@ function biterUtils.makeBiter(attributes)
         enemy_map_color = ((not settings.startup["rampant--oldRedEnemyMapColor"].value) and attributes.tint2) or nil,
         affected_by_tiles = settings.startup["rampant--unitsAffectedByTiles"].value,
         dying_sound = attributes.dyingSounds,
-        working_sound =  attributes.workingSounds,  --problem sound
+--        working_sound =  attributes.workingSounds,  --problem sound
         walking_sound = attributes.walkingSounds,  --problem sound
         running_sound_animation_positions = {2,},
         run_animation = biterrunanimation(attributes.scale, attributes.tint, attributes.tint2 or attributes.tint, attributes.altBiter)
@@ -351,7 +351,7 @@ function biterUtils.makeSpitter(attributes)
         enemy_map_color = ((not settings.startup["rampant--oldRedEnemyMapColor"].value) and attributes.tint2) or nil,
         dying_trigger_effect = attributes.dyingEffect,
         dying_sound = attributes.dyingSounds,
-        working_sound = attributes.workingSounds,  --problem sound
+--        working_sound = attributes.workingSounds,  --problem sound
         walking_sound = attributes.walkingSounds,  --problem sound
         running_sound_animation_positions = {2,},
         water_reflection = spitter_water_reflection(attributes.scale),

--- a/prototypes/utils/BiterUtils.lua
+++ b/prototypes/utils/BiterUtils.lua
@@ -295,8 +295,8 @@ function biterUtils.makeBiter(attributes)
         enemy_map_color = ((not settings.startup["rampant--oldRedEnemyMapColor"].value) and attributes.tint2) or nil,
         affected_by_tiles = settings.startup["rampant--unitsAffectedByTiles"].value,
         dying_sound = attributes.dyingSounds,
-        working_sound =  attributes.workingSounds,
-        walking_sound = attributes.walkingSounds,
+        working_sound =  attributes.workingSounds,  --problem sound
+        walking_sound = attributes.walkingSounds,  --problem sound
         running_sound_animation_positions = {2,},
         run_animation = biterrunanimation(attributes.scale, attributes.tint, attributes.tint2 or attributes.tint, attributes.altBiter)
     }
@@ -351,8 +351,8 @@ function biterUtils.makeSpitter(attributes)
         enemy_map_color = ((not settings.startup["rampant--oldRedEnemyMapColor"].value) and attributes.tint2) or nil,
         dying_trigger_effect = attributes.dyingEffect,
         dying_sound = attributes.dyingSounds,
-        working_sound = attributes.workingSounds,
-        walking_sound = attributes.walkingSounds,
+        working_sound = attributes.workingSounds,  --problem sound
+        walking_sound = attributes.walkingSounds,  --problem sound
         running_sound_animation_positions = {2,},
         water_reflection = spitter_water_reflection(attributes.scale),
         damaged_trigger_effect = ((not settings.startup["rampant--removeBloodParticles"].value) and makeDamagedParticle(attributes)) or nil,
@@ -577,7 +577,7 @@ function biterUtils.makeWorm(attributes)
         folding_speed = attributes.foldingSpeed or 0.015,
         folding_animation =  wormPreparingAnimation(attributes.scale, attributes.tint, "backward", attributes.tint2 or attributes.tint),
         folding_sound = attributes.foldSounds,
-        prepare_range = attributes.prepareRange or 30,
+        prepare_range = attributes.prepareRange or ( attributes.attack.range + 2.5 ),
         integration = worm_integration(attributes.scale),
         attack_parameters = attributes.attack,
         secondary_animation = true,


### PR DESCRIPTION
This change fixes old very annoying problem of abnormal biters activity when pollution cloud doesn't touch nests.
Rampant should treat pollution value below min_diffuse_value as not-diffusable pollution, because it will never spread into nest chunk -> biters can sleep well.

P.S. Problem is caused by hidden factorio engine behavior of very slow pollution absorption when pollution units value in chunk is below min_diffuse_value and there are no active pollution eaters in chunk (trees, nests, filters). I described it in Rampant Industry mod portal thread. For Rampant this problem manifestates in more dramatic way, because pollution units value in adjacent chunk reduces to min_diffuse value very fast (diffusion and immediate absorption), but then non-zero minimal pollution stays in that adjacent chunk for dozens of minutes causing a lot of biters activities without real reason.