### PR TITLE
Extending spawn creep remote call

### DIFF
--- a/libs/ChunkProcessor.lua
+++ b/libs/ChunkProcessor.lua
@@ -162,7 +162,7 @@ function chunkProcessor.processPendingUpgrades(universe, tick)
             if createdEntity and createdEntity.valid then
                 registerEnemyBaseStructure(entityData.map, createdEntity, entityData.base, true)
                 if remote.interfaces["kr-creep"] then
-                    remote.call("kr-creep", "spawn_creep_at_position", surface, foundPosition or position)
+                    remote.call("kr-creep", "spawn_creep_at_position", surface, foundPosition or position, false, createdEntity.name)
                 end
             end
         else


### PR DESCRIPTION
Adding one more parameter in kr-creep remote interface function. It allows Warmonger mod to detect creep source type.
I tested this change VS old kr-creep interface -> it's ok, not implemented parameter is ignored without errors.